### PR TITLE
Godot Principles Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.obsidian

--- a/GDScript/GDScript_main/Errors - GDScript.md
+++ b/GDScript/GDScript_main/Errors - GDScript.md
@@ -12,3 +12,5 @@ source: https://gdquest.github.io/learn-gdscript
 
 + Errors are not failures 
 > They are a checklist of issues to resolve.
+
++ Writing code that relies on external documentation to use it safely is error-prone by default.

--- a/Godot Principles/Scene Organisation - Godot.md
+++ b/Godot Principles/Scene Organisation - Godot.md
@@ -1,0 +1,35 @@
+---
+aliases:
+  - scene organisation
+  - Scene organisation
+  - Scene Organisation
+  - scene organization
+  - Scene organization
+  - Scene Organization
+---
+
+When possible, utilize focused, singular-purpose [[classes]] with [[loose coupling]] to other parts of the codebase
+
+If possible, [[Scenes - Godot|scenes]] should have no dependencies 
+
++ Scenes should be self-reliant 
++ Scenes should only rely on data internal to the scene
++ Scenes operate best when they operate alone
+
+
+Key to scene organization: 
+
++ Considering the [[Scene Tree - Godot|Scene tree]] in **relational** terms rather than **spatial** terms. 
+
+# Key questions for effective scene organization
+
++ Are the nodes dependent on their parent's existence? 
+  
+>If not, then they can thrive all by themselves somewhere else. 
+>
+>If they are dependent, then it stands to reason that they should be children of that parent (and likely part of that parent's scene if they aren't already).
+>[[Parent-child relationships - Godot|Parent-child relationships]] 
+
++ Are nodes themselves components? 
+>Not at all. Godot's [[Nodes - Godot|node]] [[Trees - Godot|trees]] form an [[Aggregation - Godot|aggregation]] relationship, not one of composition. 
+>But while you still have the flexibility to move nodes around, it is still best when such moves are unnecessary by default.

--- a/Godot Terminology/Nodes - Godot.md
+++ b/Godot Terminology/Nodes - Godot.md
@@ -35,6 +35,8 @@ Godot offers many different types of objects called nodes, each with a specific 
 
 In other words, Godot's nodes do not work like components in some other game engines.
 
+A game should have an entry point; for traditional applications, this is normally a "main" function. In Godot, it's a [[Main node]].
+
 # Root node 
 
 A single node that is at the base of a [[Scene Tree - Godot|scene tree]]

--- a/Godot Terminology/Parent-child relationships - Godot.md
+++ b/Godot Terminology/Parent-child relationships - Godot.md
@@ -1,0 +1,8 @@
+---
+aliases:
+  - parent-child relationships
+  - parent and child
+  - Parent-child relationships
+  - parent and child nodes
+---
+Each subsystem within your game should have its own section within the  [[Scene Tree - Godot|Scene tree]]. You should use parent-child relationships only in cases where [[Nodes - Godot|nodes]] are effectively elements of their parents.

--- a/Godot Terminology/Scene Tree - Godot.md
+++ b/Godot Terminology/Scene Tree - Godot.md
@@ -6,6 +6,8 @@ aliases:
   - scene trees
 ---
 [[Godot basics]]
-All your game's [[Scenes - Godot|Scenes]] come together in the **scene tree**, literally a [[Trees - Godot|tree]] of scenes. And as scenes are trees of nodes, the scene tree also is a tree of nodes. But it's easier to think of your game in terms of scenes as they can represent characters, weapons, doors, or your user interface.
+All your game's [[Scenes - Godot|Scenes]] come together in the **scene tree**: a [[Trees - Godot|tree]] of scenes. And as scenes are trees of nodes, the scene tree also is a tree of nodes. But it's easier to think of your game in terms of scenes as they can represent characters, weapons, doors, or your user interface.
 
-[[Root Node - Godot|Root node]] = A single node that is at the base of a [[Scene Tree - Godot|scene tree]]
+[[Root Node - Godot|Root node]] = A single node that is at the base of a [[Scene Tree - Godot|scene tree]] 
+
+Each subsystem within your game should have its own section within the SceneTree. You should use [[parent-child relationships]] only in cases where nodes are effectively elements of their parents.


### PR DESCRIPTION
Created the Godot Principles folder with its initial commit, a note describing best practices for Scene Organisation within Godot according to godot docs.

Added a note for parent-child relationships, edited the syntax of other notes within the GDScript and Godot Terminology folders